### PR TITLE
Add LiveCursors

### DIFF
--- a/src/app/(cord)/puzzle/[mode]/[id]/puzzle-page.css
+++ b/src/app/(cord)/puzzle/[mode]/[id]/puzzle-page.css
@@ -29,3 +29,7 @@
 .name[data-coop-text-playerId="player-7"] {
     color: aqua;
 }
+
+.cord-live-cursors-cursor {
+  opacity: 0.75;
+}


### PR DESCRIPTION
Feat: Adding live cursors

It works well.
With one big catch:
It is super annoying that the cursors can easily hide 2,3 cells.
One workaround is the opacity (in this PR as well).

Also the color won't match. We may have to use a Custom cursor. Or only showing avatar.

![image](https://github.com/dmmiller/cordoku/assets/529333/31573144-4b2f-4581-afe3-2b99c0bfd9ed)

